### PR TITLE
AE-2024: Report Artifact Analysis Dependency

### DIFF
--- a/processors/_common_/ae-kontinuum-processors.xml
+++ b/processors/_common_/ae-kontinuum-processors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <!--
@@ -34,4 +34,22 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.metaeffekt.core</groupId>
+                    <artifactId>ae-inventory-maven-plugin</artifactId>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.metaeffekt.artifact.analysis</groupId>
+                            <artifactId>ae-artifact-analysis</artifactId>
+                            <version>${ae.artifact.analysis.version}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>


### PR DESCRIPTION
- https://github.com/org-metaeffekt/metaeffekt-artifact-analysis/pull/539
- https://github.com/org-metaeffekt/metaeffekt-core/pull/380

The new report plugin architecture requires that artifact analysis is known on the class path when generating the vulnerability-related reports. This PR adds a `<pluginManagement>` for `org.metaeffekt.core:ae-inventory-maven-plugin` to `com.metaeffekt.artifact.analysis:ae-artifact-analysis:${ae.artifact.analysis.version}` to enable all plugin executions of that type to automatically depend on artifact analysis.