### PR TITLE
AE-1122: Threat Modeling support

### DIFF
--- a/processors/advise/advise_enrich-inventory.md
+++ b/processors/advise/advise_enrich-inventory.md
@@ -22,6 +22,7 @@ of this repository.
 | param.correlation.dir            | yes      | The directory containing vulnerability correlation information.                                |
 | param.assessment.dirs            | yes      | A comma separated list of all directories or files containing assessments.                     |
 | param.context.dirs               | yes      | A comma separated list of all directories or files containing contexts.                        |
+| param.param.threat.catalog.file  | no       | A file pointing to the threat catalog to use.                                                  |
 | param.security.policy.file       | yes      | The security policy file to use.                                                               |
 | param.security.policy.active.ids | no       | The activeIds of the security policy configurations to use for enrichment.                     |
 | param.activate.*                 | no       | Switches determining which vulnerability databases are utilized during the enrichment process. |

--- a/processors/advise/advise_enrich-inventory.xml
+++ b/processors/advise/advise_enrich-inventory.xml
@@ -45,6 +45,7 @@
 
         <param.activate.status>true</param.activate.status>
         <param.activate.keywords>true</param.activate.keywords>
+        <param.activate.threat>false</param.activate.threat>
         <param.activate.validation>false</param.activate.validation>
 
         <!-- ghsa unreviewed filter -->
@@ -243,6 +244,11 @@
                                 <active>${param.activate.kev}</active>
                             </kevEnrichment>
 
+                            <threatEnrichment>
+                                <active>${param.activate.threat}</active>
+                                <catalogFile>${param.threat.catalog.file}</catalogFile>
+                            </threatEnrichment>
+
                             <!-- Inventory Post Processing -->
                             <vulnerabilityStatusPostProcessingEnrichment>
                                 <active>true</active>
@@ -305,6 +311,9 @@
                                 </requireProperty>
                                 <requireProperty>
                                     <property>param.assessment.dirs</property>
+                                </requireProperty>
+                                <requireProperty>
+                                    <property>param.threat.catalog.file</property>
                                 </requireProperty>
                                 <requireProperty>
                                     <property>param.security.policy.file</property>


### PR DESCRIPTION
Added two parameters:

- `param.activate.threat` (default `false`): when assigned to `true`, will activate the threat enrichment phase. This will implicitly also activate all threat features in the dashboard, as it determines this by checking whether the threat enrichment ran and was active.
- `param.threat.catalog.file`: path to the YAML threat catalog file.