### PR TITLE
AE-2000: CSAF Index Refactor

### DIFF
--- a/processors/advise/advise_enrich-inventory.xml
+++ b/processors/advise/advise_enrich-inventory.xml
@@ -219,10 +219,6 @@
                                 <active>${param.activate.certeu}</active>
                             </certEuAdvisorEnrichment>
 
-                            <csafAdvisorEnrichment>
-                                <active>${param.activate.csaf}</active>
-                            </csafAdvisorEnrichment>
-
                             <osvAdvisorFillDetailsEnrichment>
                                 <active>${param.activate.osv}</active>
                                 <includeAdvisoryProviders></includeAdvisoryProviders>


### PR DESCRIPTION
removes defunct "CSAF Advisor Detail Filling" enrichment-step from enrichment config

[AA](https://github.com/org-metaeffekt/metaeffekt-artifact-analysis/pull/531)